### PR TITLE
Check for Engin-injected parameter using the dependency function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-11-30
+
+### Fixed
+
+- Fixed compatibility with `fastapi>=0.121.3`
+  - FastAPI `Depends` [was changed to a frozen dataclass in `v0.121.3`](https://fastapi.tiangolo.com/release-notes/#01213). 
+  - Engin no longer attaches a magic `__engin__` attribute to `Depends` for dependency detection in the `engin graph` tool.
+  - FastAPI dependencies created via `engin.Inject()` are now identified by a dedicated function name (`__inner_engin_dependency__`).
+
 ## [0.3.0] - 2025-11-12
 
 ### Added


### PR DESCRIPTION
# Compatibility fix for `FastAPI>=0.121.3`

https://fastapi.tiangolo.com/release-notes/#01213

Due to the recent FastAPI release making `Depends` object a `dataclass`, using custom `Depends.__engin__` attribute is no longer possible.

The suggested fix leverages an approach which depends less on the internals of the FastAPI, and interacts with its public API — it checks for `Depends.dependency` function name (that is created by __engin__). 

The only potential issue, is someone using the same dependency function name `__inner_engin_dependency__`, which is highly unlikely.