### PR TITLE
feat: add block-scoped modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a new concept: `Modify` & `@modify` which allows you to alter values already
-  provided in the graph. Currently these are global and Engin only supports a single
-  modifier per type. This will be relaxed in a future release.
+  provided in the graph.
 
 
 ## [0.3.1] - 2025-11-29

--- a/docs/concepts/blocks.md
+++ b/docs/concepts/blocks.md
@@ -85,3 +85,9 @@ class ExampleBlock(Block):
     The `self` parameter in these methods is replaced with an empty object at runtime so
     should not be used. Blocks do not need to be instantiated to be passed to Engin as an
     option.
+
+!!!tip
+
+    Modifiers defined inside a Block are **scoped to that block** — they only affect
+    resolutions within the block's own invocations. See the
+    [modifiers documentation](modifiers.md#using-modifiers-in-blocks) for details.

--- a/docs/concepts/modifiers.md
+++ b/docs/concepts/modifiers.md
@@ -198,6 +198,43 @@ engin = Engin(
 )
 ```
 
+### Nested block composition
+
+When blocks are nested (a block includes another block via `options`), inner blocks inherit
+modifiers from their outer blocks. If both define a modifier for the same type, the outer
+modifier is applied first and its result is passed to the inner modifier:
+
+```python
+from typing import ClassVar
+from engin import Block, Engin, Provide, modify, invoke
+from engin._option import Option
+
+
+class InnerBlock(Block):
+    @modify
+    def add_suffix(self, value: str) -> str:
+        return f"{value}!"
+
+    @invoke
+    def print_greeting(self, greeting: str) -> None:
+        print(greeting)  # FOO! (outer then inner modifier)
+
+
+class OuterBlock(Block):
+    options: ClassVar[list[Option]] = [InnerBlock()]
+
+    @modify
+    def upper(self, value: str) -> str:
+        return value.upper()
+
+
+engin = Engin(Provide(lambda: "foo", as_type=str), OuterBlock())
+```
+
+In this example, `InnerBlock`'s invocation sees the value after both modifiers are applied:
+`"foo"` → `"FOO"` (outer) → `"FOO!"` (inner). An inner block without its own modifier for
+the type will simply inherit the outer block's modifier.
+
 The `@modify` decorator accepts the same parameters as `Modify`, such as `override=True`:
 
 ```python

--- a/docs/concepts/modifiers.md
+++ b/docs/concepts/modifiers.md
@@ -99,10 +99,11 @@ await engin.assembler.build(int)  # returns 2, call_count is still 1
 ```
 
 
-## Only one modifier per type
+## Only one modifier per type per scope
 
-Engin currently supports only one modifier per type. If you register multiple modifiers
-for the same type, you must use `override=True` on the replacement modifier.
+Engin supports one modifier per type at each scope level (global or per-block). If you
+register multiple modifiers for the same type at the same scope level, you must use
+`override=True` on the replacement modifier.
 
 ```python
 from engin import Engin, Modify, Provide
@@ -135,26 +136,66 @@ print(result)  # hello!!!
 ## Using modifiers in Blocks
 
 Within a Block, you can use the `@modify` decorator to define modifiers as methods.
+Modifiers defined inside a Block are **scoped to that block** — they only affect
+resolutions within the block's own invocations and do not affect other blocks or
+top-level invocations.
 
 ```python
-from engin import Block, Engin, modify, provide
+from engin import Block, Engin, Invoke, Provide, modify, invoke
 
 
 class GreetingBlock(Block):
-    @provide
-    def make_greeting(self) -> str:
-        return "hello"
-
     @modify
     def add_excitement(self, greeting: str) -> str:
         return f"{greeting}!"
 
+    @invoke
+    def print_greeting(self, greeting: str) -> None:
+        print(greeting)  # hello! (modified)
 
-engin = Engin(GreetingBlock())
 
-result = await engin.assembler.build(str)
+def print_raw(greeting: str) -> None:
+    print(greeting)  # hello (unmodified)
 
-print(result)  # hello!
+
+def make_greeting() -> str:
+    return "hello"
+
+
+engin = Engin(Provide(make_greeting), GreetingBlock(), Invoke(print_raw))
+```
+
+In this example, `GreetingBlock`'s `print_greeting` invocation sees the modified value
+`"hello!"`, while the top-level `print_raw` invocation sees the raw value `"hello"`.
+
+### Composing with global modifiers
+
+Block modifiers compose with global modifiers. When both exist for the same type, the
+block modifier receives the globally-modified value as its input:
+
+```python
+from engin import Block, Engin, Modify, Provide, modify, invoke
+
+
+def add_prefix(value: str) -> str:
+    return f"[INFO] {value}"
+
+
+class GreetingBlock(Block):
+    @modify
+    def upper(self, value: str) -> str:
+        return value.upper()
+
+    @invoke
+    def print_greeting(self, greeting: str) -> None:
+        print(greeting)  # [INFO] HELLO (global then block modifier)
+
+
+engin = Engin(
+    Provide(lambda: "hello", as_type=str),
+    Modify(add_prefix),
+    GreetingBlock(),
+)
 ```
 
 The `@modify` decorator accepts the same parameters as `Modify`, such as `override=True`:

--- a/src/engin/_assembler.py
+++ b/src/engin/_assembler.py
@@ -12,7 +12,12 @@ from typing_extensions import Self
 
 from engin._dependency import Dependency, Modify, Provide, Supply
 from engin._type_utils import TypeId
-from engin.exceptions import NotInScopeError, ProviderError, TypeNotProvidedError
+from engin.exceptions import (
+    ModifierError,
+    NotInScopeError,
+    ProviderError,
+    TypeNotProvidedError,
+)
 
 LOG = logging.getLogger("engin")
 
@@ -33,6 +38,7 @@ class _ScopeNode:
     name: str
     cache: dict[TypeId, Any] = field(default_factory=dict)
     modified_cache: dict[TypeId, Any] = field(default_factory=dict)
+    modifiers: dict[TypeId, "Modify[Any]"] = field(default_factory=dict)
     parent: "_ScopeNode | None" = None
 
     def find(self, type_id: TypeId) -> tuple[bool, Any]:
@@ -56,6 +62,10 @@ class _ScopeNode:
         """
         Search for a modified cached value by walking up the scope chain.
 
+        Stops at the first node that owns a modifier for *type_id* so that a
+        child scope with its own modifier does not inherit a parent's cached
+        modified value (the child's modifier must be applied independently).
+
         Args:
             type_id: the type to look up.
 
@@ -66,8 +76,34 @@ class _ScopeNode:
         while node is not None:
             if type_id in node.modified_cache:
                 return True, node.modified_cache[type_id]
+            if type_id in node.modifiers:
+                return False, None
             node = node.parent
         return False, None
+
+    def find_modifier(
+        self, type_id: TypeId, skip: "set[int] | None" = None
+    ) -> tuple["Modify[Any] | None", "_ScopeNode | None"]:
+        """
+        Search for a modifier by walking up the scope chain.
+
+        Args:
+            type_id: the type to look up.
+            skip: optional set of ``id(modifier)`` values to skip (modifiers
+                currently being applied — prevents infinite recursion while
+                still allowing composition with parent-scope modifiers).
+
+        Returns ``(modifier, source_node)`` where *source_node* is the node
+        that owns the modifier, or ``(None, None)`` if no modifier exists.
+        """
+        node: _ScopeNode | None = self
+        while node is not None:
+            if type_id in node.modifiers:
+                mod = node.modifiers[type_id]
+                if skip is None or id(mod) not in skip:
+                    return mod, node
+            node = node.parent
+        return None, None
 
     def has_scope(self, name: str) -> bool:
         """
@@ -138,11 +174,11 @@ class Assembler:
     def __init__(self, providers: Iterable[Provide]) -> None:
         self._providers: dict[TypeId, Provide[Any]] = {}
         self._multiproviders: dict[TypeId, list[Provide[list[Any]]]] = defaultdict(list)
-        self._modifiers: dict[TypeId, Modify[Any]] = {}
         self._lock = asyncio.Lock()
         self._graph_cache: dict[TypeId, list[Provide]] = defaultdict(list)
         self._root_node = _ScopeNode(name="__root__")
         self._scope_var: ContextVar[_ScopeNode] = ContextVar("_scope", default=self._root_node)
+        self._modifiers_on_stack: set[int] = set()
 
         for provider in providers:
             type_id = provider.return_type_id
@@ -182,7 +218,7 @@ class Assembler:
         assembler = cls(tuple())  # noqa: C408
         assembler._providers = providers
         assembler._multiproviders = multiproviders
-        assembler._modifiers = modifiers or {}
+        assembler._root_node.modifiers.update(modifiers or {})
         return assembler
 
     @property
@@ -204,10 +240,38 @@ class Assembler:
             An AssembledDependency, which can be awaited to construct the final value.
         """
         async with self._lock:
-            return AssembledDependency(
-                dependency=dependency,
-                bound_args=await self._bind_arguments(dependency.signature),
-            )
+            return await self._assemble_unlocked(dependency)
+
+    async def _assemble_unlocked(
+        self, dependency: Dependency[Any, T]
+    ) -> AssembledDependency[T]:
+        """Assemble without acquiring the lock. Caller must hold self._lock."""
+        return AssembledDependency(
+            dependency=dependency,
+            bound_args=await self._bind_arguments(dependency.signature),
+        )
+
+    async def _apply_modifier(self, modifier: Modify[T]) -> T:
+        """Apply a modifier, assembling its dependencies first. Caller must hold self._lock.
+
+        Marks the modifier's type as on-stack during execution to prevent infinite
+        recursion when the modifier's own parameters include the type it modifies
+        (mirroring dig's ``decoratorOnStack`` mechanism).
+        """
+        mod_id = id(modifier)
+        self._modifiers_on_stack.add(mod_id)
+        try:
+            assembled = await self._assemble_unlocked(modifier)
+            try:
+                return await assembled()
+            except Exception as err:
+                raise ModifierError(
+                    modifier=modifier,
+                    error_type=type(err),
+                    error_message=str(err),
+                ) from err
+        finally:
+            self._modifiers_on_stack.discard(mod_id)
 
     async def build(self, type_: type[T]) -> T:
         """
@@ -228,8 +292,14 @@ class Assembler:
         Returns:
             The constructed value.
         """
+        async with self._lock:
+            return await self._build_unlocked(type_)
+
+    async def _build_unlocked(self, type_: type[T]) -> T:
+        """Build without acquiring the lock. Caller must hold self._lock."""
         type_id = TypeId.from_type(type_)
         scope = self._scope_var.get()
+        modifier, modifier_source = scope.find_modifier(type_id, skip=self._modifiers_on_stack)
 
         # Check modified cache (walks scope chain up to root)
         found, val = scope.find_modified(type_id)
@@ -240,7 +310,7 @@ class Assembler:
             # Multiproviders are never scoped, so they always live in the root cache.
 
             # Cache hit (skip when modifier exists — need to fall through to apply it)
-            if type_id not in self._modifiers:
+            if modifier is None:
                 found, val = scope.find(type_id)
                 if found:
                     return cast("T", val)
@@ -252,7 +322,7 @@ class Assembler:
 
                 out: list[Any] = []
                 for p in providers:
-                    assembled_dep = await self.assemble(p)
+                    assembled_dep = await self._assemble_unlocked(p)
                     try:
                         out.extend(await assembled_dep())
                     except Exception as err:
@@ -264,10 +334,9 @@ class Assembler:
                 self._root_node.cache[type_id] = out
 
             # Apply modifier if exists
-            if type_id in self._modifiers:
-                assembled = await self.assemble(self._modifiers[type_id])
-                modified_value = await assembled()
-                self._root_node.modified_cache[type_id] = modified_value
+            if modifier is not None and modifier_source is not None:
+                modified_value = await self._apply_modifier(modifier)
+                modifier_source.modified_cache[type_id] = modified_value
                 return cast("T", modified_value)
 
             return cast("T", self._root_node.cache[type_id])
@@ -276,7 +345,7 @@ class Assembler:
 
         # Check scope chain cache (skip when modifier exists — we need to fall through
         # to apply it)
-        if type_id not in self._modifiers:
+        if modifier is None:
             found, val = scope.find(type_id)
             if found:
                 return cast("T", val)
@@ -294,7 +363,7 @@ class Assembler:
                     scope_stack=scope.scope_names,
                 )
 
-            assembled_dependency = await self.assemble(provider)
+            assembled_dependency = await self._assemble_unlocked(provider)
             try:
                 value = await assembled_dependency()
             except Exception as err:
@@ -310,13 +379,12 @@ class Assembler:
                 self._root_node.cache[type_id] = value
 
         # Apply modifier if exists
-        if type_id in self._modifiers:
-            assembled = await self.assemble(self._modifiers[type_id])
-            modified_value = await assembled()
+        if modifier is not None and modifier_source is not None:
+            modified_value = await self._apply_modifier(modifier)
             if self._is_scoped_type(type_id):
                 scope.modified_cache[type_id] = modified_value
             else:
-                self._root_node.modified_cache[type_id] = modified_value
+                modifier_source.modified_cache[type_id] = modified_value
             return cast("T", modified_value)
 
         found, val = scope.find(type_id)
@@ -442,16 +510,48 @@ class Assembler:
                 args.append(object())
                 continue
             param_key = TypeId.from_type(param.annotation)
-            found, val = scope.find(param_key)
-            if not found:
-                await self._satisfy(param_key)
-                found, val = scope.find(param_key)
+            val = await self._resolve_param(scope, param_key)
             if param.kind == param.POSITIONAL_ONLY:
                 args.append(val)
             else:
                 kwargs[param.name] = val
 
         return signature.bind(*args, **kwargs)
+
+    async def _resolve_param(self, scope: _ScopeNode, param_key: TypeId) -> Any:
+        """Resolve a single parameter, applying modifiers if present."""
+        # Skip modifiers currently being applied (on-stack) to avoid infinite
+        # recursion while still allowing composition with parent-scope modifiers.
+        modifier, modifier_source = scope.find_modifier(
+            param_key, skip=self._modifiers_on_stack
+        )
+
+        # Check modified cache first (already-applied modifier)
+        found, val = scope.find_modified(param_key)
+        if found:
+            return val
+
+        # Check raw cache (only return early if no modifier needs applying)
+        if modifier is None:
+            found, val = scope.find(param_key)
+            if found:
+                return val
+
+        # Satisfy the raw value if not yet cached
+        if not scope.find(param_key)[0]:
+            await self._satisfy(param_key)
+
+        # Apply modifier if one exists
+        if modifier is not None and modifier_source is not None:
+            modified_value = await self._apply_modifier(modifier)
+            if self._is_scoped_type(param_key):
+                scope.modified_cache[param_key] = modified_value
+            else:
+                modifier_source.modified_cache[param_key] = modified_value
+            return modified_value
+
+        _, val = scope.find(param_key)
+        return val
 
 
 class _ScopeContextManager:

--- a/src/engin/_block.py
+++ b/src/engin/_block.py
@@ -95,6 +95,7 @@ class Block:
     @classmethod
     def apply(cls, engin: "Engin") -> None:
         block_name = cls.name or cls.__name__
+        engin._register_block_scope(block_name)
         for option in chain(cls.options, cls._method_options()):
             if isinstance(option, Dependency):
                 option._block_name = block_name

--- a/src/engin/_block.py
+++ b/src/engin/_block.py
@@ -96,10 +96,14 @@ class Block:
     def apply(cls, engin: "Engin") -> None:
         block_name = cls.name or cls.__name__
         engin._register_block_scope(block_name)
-        for option in chain(cls.options, cls._method_options()):
-            if isinstance(option, Dependency):
-                option._block_name = block_name
-            option.apply(engin)
+        engin._block_scope_stack.append(block_name)
+        try:
+            for option in chain(cls.options, cls._method_options()):
+                if isinstance(option, Dependency):
+                    option._block_name = block_name
+                option.apply(engin)
+        finally:
+            engin._block_scope_stack.pop()
 
     @classmethod
     def _method_options(cls) -> Iterable[Provide | Invoke | Modify]:

--- a/src/engin/_dependency.py
+++ b/src/engin/_dependency.py
@@ -365,12 +365,21 @@ class Modify(Dependency[Any, T]):
 
     def apply(self, engin: "Engin") -> None:
         type_id = self._modifies_type_id
-        if type_id in engin._modifiers and not self._override:
-            existing = engin._modifiers[type_id]
-            raise RuntimeError(
-                f"{self} conflicts with existing {existing}, use override=True to replace"
-            )
-        engin._modifiers[type_id] = self
+        if self._block_name and self._block_name in engin._block_nodes:
+            block_node = engin._block_nodes[self._block_name]
+            if type_id in block_node.modifiers and not self._override:
+                existing = block_node.modifiers[type_id]
+                raise RuntimeError(
+                    f"{self} conflicts with existing {existing}, use override=True to replace"
+                )
+            block_node.modifiers[type_id] = self
+        else:
+            if type_id in engin._modifiers and not self._override:
+                existing = engin._modifiers[type_id]
+                raise RuntimeError(
+                    f"{self} conflicts with existing {existing}, use override=True to replace"
+                )
+            engin._modifiers[type_id] = self
 
     def _resolve_modifies_type(self) -> TypeId:
         """First parameter is the type being modified."""

--- a/src/engin/_engin.py
+++ b/src/engin/_engin.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from anyio import create_task_group, open_signal_receiver
 
-from engin._assembler import AssembledDependency, Assembler
+from engin._assembler import AssembledDependency, Assembler, _ScopeNode
 from engin._dependency import Invoke, Modify, Provide, Supply
 from engin._graph import DependencyGrapher, Node
 from engin._lifecycle import Lifecycle
@@ -115,8 +115,9 @@ class Engin:
         self._multiproviders: dict[TypeId, list[Provide]] = defaultdict(list)
         self._modifiers: dict[TypeId, Modify] = {}
         self._invocations: list[Invoke] = []
+        self._block_nodes: dict[str, _ScopeNode] = {}
 
-        # populates the above
+        # populates the above (including _block_nodes via Block.apply)
         for option in chain(self._LIB_OPTIONS, options):
             option.apply(self)
 
@@ -127,6 +128,19 @@ class Engin:
             modifiers=self._modifiers,
         )
         self._assembler.add(Supply(self._assembler))
+
+        # Wire block scope nodes as children of the root node
+        for name, block_node in self._block_nodes.items():
+            self._block_nodes[name] = _ScopeNode(
+                name=block_node.name,
+                modifiers=block_node.modifiers,
+                parent=self._assembler._root_node,
+            )
+
+    def _register_block_scope(self, block_name: str) -> None:
+        """Create a persistent scope node for a block (called during Block.apply)."""
+        if block_name not in self._block_nodes:
+            self._block_nodes[block_name] = _ScopeNode(name=block_name)
 
     @property
     def assembler(self) -> Assembler:
@@ -143,17 +157,37 @@ class Engin:
             raise EnginError("Engin is not idle, unable to start")
 
         LOG.info("starting engin")
-        assembled_invocations: list[AssembledDependency] = [
-            await self._assembler.assemble(invocation) for invocation in self._invocations
-        ]
+        assembled_invocations: list[AssembledDependency] = []
+        for invocation in self._invocations:
+            block_name = invocation.block_name
+            if block_name and block_name in self._block_nodes:
+                token = self._assembler._scope_var.set(self._block_nodes[block_name])
+                try:
+                    assembled_invocations.append(await self._assembler.assemble(invocation))
+                finally:
+                    self._assembler._scope_var.reset(token)
+            else:
+                assembled_invocations.append(await self._assembler.assemble(invocation))
 
-        for invocation in assembled_invocations:
-            try:
-                await invocation()
-            except Exception as err:
-                name = invocation.dependency.name
-                LOG.error(f"invocation '{name}' errored, exiting", exc_info=err)
-                raise
+        for assembled in assembled_invocations:
+            block_name = assembled.dependency.block_name
+            if block_name and block_name in self._block_nodes:
+                token = self._assembler._scope_var.set(self._block_nodes[block_name])
+                try:
+                    await assembled()
+                except Exception as err:
+                    name = assembled.dependency.name
+                    LOG.error(f"invocation '{name}' errored, exiting", exc_info=err)
+                    raise
+                finally:
+                    self._assembler._scope_var.reset(token)
+            else:
+                try:
+                    await assembled()
+                except Exception as err:
+                    name = assembled.dependency.name
+                    LOG.error(f"invocation '{name}' errored, exiting", exc_info=err)
+                    raise
 
         lifecycle = await self._assembler.build(Lifecycle)
 

--- a/src/engin/_engin.py
+++ b/src/engin/_engin.py
@@ -116,6 +116,8 @@ class Engin:
         self._modifiers: dict[TypeId, Modify] = {}
         self._invocations: list[Invoke] = []
         self._block_nodes: dict[str, _ScopeNode] = {}
+        self._block_parents: dict[str, str | None] = {}
+        self._block_scope_stack: list[str] = []
 
         # populates the above (including _block_nodes via Block.apply)
         for option in chain(self._LIB_OPTIONS, options):
@@ -129,18 +131,29 @@ class Engin:
         )
         self._assembler.add(Supply(self._assembler))
 
-        # Wire block scope nodes as children of the root node
+        # Wire block scope nodes into a tree mirroring the block nesting.
+        # Blocks are registered depth-first during apply, so parents are always
+        # inserted before children — iterating in insertion order is safe.
+        wired: dict[str, _ScopeNode] = {}
         for name, block_node in self._block_nodes.items():
-            self._block_nodes[name] = _ScopeNode(
-                name=block_node.name,
+            parent_name = self._block_parents.get(name)
+            if parent_name is not None:
+                parent = wired[parent_name]
+            else:
+                parent = self._assembler._root_node
+            wired[name] = _ScopeNode(
+                name=name,
                 modifiers=block_node.modifiers,
-                parent=self._assembler._root_node,
+                parent=parent,
             )
+        self._block_nodes = wired
 
     def _register_block_scope(self, block_name: str) -> None:
         """Create a persistent scope node for a block (called during Block.apply)."""
         if block_name not in self._block_nodes:
+            parent = self._block_scope_stack[-1] if self._block_scope_stack else None
             self._block_nodes[block_name] = _ScopeNode(name=block_name)
+            self._block_parents[block_name] = parent
 
     @property
     def assembler(self) -> Assembler:

--- a/src/engin/exceptions.py
+++ b/src/engin/exceptions.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, Any
 
-from engin._dependency import Provide
 from engin._type_utils import TypeId
 
 if TYPE_CHECKING:
     from engin._block import Block
+    from engin._dependency import Modify, Provide
 
 
 class EnginError(Exception):
@@ -53,7 +53,7 @@ class ProviderError(AssemblerError):
 
     def __init__(
         self,
-        provider: Provide[Any],
+        provider: "Provide[Any]",
         error_type: type[Exception],
         error_message: str,
     ) -> None:
@@ -69,12 +69,35 @@ class ProviderError(AssemblerError):
         return self.message
 
 
+class ModifierError(AssemblerError):
+    """
+    Raised when a Modifier errors during Assembly.
+    """
+
+    def __init__(
+        self,
+        modifier: "Modify[Any]",
+        error_type: type[Exception],
+        error_message: str,
+    ) -> None:
+        self.modifier = modifier
+        self.error_type = error_type
+        self.error_message = error_message
+        self.message = (
+            f"modifier '{modifier.name}' errored with error "
+            f"({error_type.__name__}): '{error_message}'"
+        )
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class NotInScopeError(AssemblerError):
     """
     Raised when a Provider is requested outside of its scope.
     """
 
-    def __init__(self, provider: Provide[Any], scope_stack: list[str]) -> None:
+    def __init__(self, provider: "Provide[Any]", scope_stack: list[str]) -> None:
         self.provider = provider
         self.message = (
             f"provider '{provider.name}' was requested outside of its specified scope "
@@ -89,6 +112,7 @@ __all__ = [
     "AssemblerError",
     "EnginError",
     "InvalidBlockError",
+    "ModifierError",
     "NotInScopeError",
     "ProviderError",
     "TypeNotProvidedError",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -331,7 +331,7 @@ async def test_assembler_with_modifier():
         modifiers={},
     )
     assembler.add(Provide(make_str))
-    assembler._modifiers[Modify(add_prefix).modifies_type_id] = Modify(add_prefix)
+    assembler._root_node.modifiers[Modify(add_prefix).modifies_type_id] = Modify(add_prefix)
 
     result = await assembler.build(str)
     assert result == "prefix_foo"
@@ -438,7 +438,7 @@ async def test_assembler_modifier_with_multiprovider():
     modifier = Modify(double_all)
 
     assembler = Assembler([Provide(make_ints_a), Provide(make_ints_b)])
-    assembler._modifiers[modifier.modifies_type_id] = modifier
+    assembler._root_node.modifiers[modifier.modifies_type_id] = modifier
 
     result = await assembler.build(list[int])
     assert result == [2, 4, 6, 8]

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,8 +1,10 @@
+from typing import ClassVar
 from unittest.mock import Mock
 
 import pytest
 
 from engin import Block, Engin, Invoke, Modify, Provide, invoke, modify, provide
+from engin._option import Option
 from engin.exceptions import InvalidBlockError
 
 
@@ -202,3 +204,72 @@ async def test_global_modifier_applied_via_engin():
     await engin.stop()
 
     assert received == "prefix_foo", f"invocation should see modified value, got {received}"
+
+
+async def test_nested_block_modifier_composes_with_outer():
+    """Inner block invocation sees outer block's modifier via scope chain."""
+    received_inner: str | None = None
+    received_outer: str | None = None
+
+    class InnerBlock(Block):
+        @invoke
+        def check_inner(self, value: str) -> None:
+            nonlocal received_inner
+            received_inner = value
+
+    class OuterBlock(Block):
+        options: ClassVar[list[Option]] = [InnerBlock()]
+
+        @modify
+        def upper(self, value: str) -> str:
+            return value.upper()
+
+        @invoke
+        def check_outer(self, value: str) -> None:
+            nonlocal received_outer
+            received_outer = value
+
+    def make_str() -> str:
+        return "foo"
+
+    engin = Engin(Provide(make_str), OuterBlock())
+    await engin.start()
+    await engin.stop()
+
+    assert received_outer == "FOO", (
+        f"outer block should see its own modifier, got {received_outer}"
+    )
+    assert received_inner == "FOO", (
+        f"inner block should see outer block's modifier, got {received_inner}"
+    )
+
+
+async def test_nested_block_modifiers_compose_inner_over_outer():
+    """Inner block modifier composes with outer block modifier."""
+    received: str | None = None
+
+    class InnerBlock(Block):
+        @modify
+        def add_suffix(self, value: str) -> str:
+            return f"{value}!"
+
+        @invoke
+        def check(self, value: str) -> None:
+            nonlocal received
+            received = value
+
+    class OuterBlock(Block):
+        options: ClassVar[list[Option]] = [InnerBlock()]
+
+        @modify
+        def upper(self, value: str) -> str:
+            return value.upper()
+
+    def make_str() -> str:
+        return "foo"
+
+    engin = Engin(Provide(make_str), OuterBlock())
+    await engin.start()
+    await engin.stop()
+
+    assert received == "FOO!", f"inner should see outer then inner modifier, got {received}"

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from engin import Block, Engin, invoke, modify, provide
+from engin import Block, Engin, Invoke, Modify, Provide, invoke, modify, provide
 from engin.exceptions import InvalidBlockError
 
 
@@ -86,3 +86,119 @@ def test_block_modify_with_override():
     options = list(my_block._method_options())
 
     assert len(options) == 2
+
+
+async def test_block_scoped_modifier_only_affects_block_invocations():
+    """Modifier in a block only affects that block's invocations, not outside ones."""
+    received_in_block: str | None = None
+    received_outside: str | None = None
+
+    class MyBlock(Block):
+        @modify
+        def upper(self, value: str) -> str:
+            return value.upper()
+
+        @invoke
+        def check(self, value: str) -> None:
+            nonlocal received_in_block
+            received_in_block = value
+
+    def check_raw(value: str) -> None:
+        nonlocal received_outside
+        received_outside = value
+
+    def make_str() -> str:
+        return "foo"
+
+    engin = Engin(Provide(make_str), MyBlock(), Invoke(check_raw))
+    await engin.start()
+    await engin.stop()
+
+    assert received_in_block == "FOO", (
+        f"block invocation should see modified value, got {received_in_block}"
+    )
+    assert received_outside == "foo", (
+        f"outside invocation should see raw value, got {received_outside}"
+    )
+
+
+async def test_block_scoped_modifier_does_not_affect_other_block():
+    """Modifier in BlockA does not affect BlockB's invocations."""
+    received_a: str | None = None
+    received_b: str | None = None
+
+    class BlockA(Block):
+        @modify
+        def upper(self, value: str) -> str:
+            return value.upper()
+
+        @invoke
+        def check_a(self, value: str) -> None:
+            nonlocal received_a
+            received_a = value
+
+    class BlockB(Block):
+        @invoke
+        def check_b(self, value: str) -> None:
+            nonlocal received_b
+            received_b = value
+
+    def make_str() -> str:
+        return "foo"
+
+    engin = Engin(Provide(make_str), BlockA(), BlockB())
+    await engin.start()
+    await engin.stop()
+
+    assert received_a == "FOO", f"BlockA should see modified value, got {received_a}"
+    assert received_b == "foo", f"BlockB should see raw value, got {received_b}"
+
+
+async def test_block_modifier_composes_with_global_modifier():
+    """Block modifier receives the globally-modified value."""
+    received: str | None = None
+
+    def make_str() -> str:
+        return "foo"
+
+    def global_prefix(value: str) -> str:
+        return f"global_{value}"
+
+    class MyBlock(Block):
+        @modify
+        def upper(self, value: str) -> str:
+            return value.upper()
+
+        @invoke
+        def check(self, value: str) -> None:
+            nonlocal received
+            received = value
+
+    engin = Engin(Provide(make_str), Modify(global_prefix), MyBlock())
+    await engin.start()
+    await engin.stop()
+
+    assert received == "GLOBAL_FOO", (
+        f"block should see global then block modifier, got {received}"
+    )
+
+
+async def test_global_modifier_applied_via_engin():
+    """Global modifier works through the Engin invocation path (not just Assembler.build)."""
+    received: str | None = None
+
+    def make_str() -> str:
+        return "foo"
+
+    def add_prefix(value: str) -> str:
+        return f"prefix_{value}"
+
+    def check(value: str) -> None:
+        nonlocal received
+        received = value
+
+    engin = Engin(Provide(make_str), Modify(add_prefix), Invoke(check))
+    await engin.start()
+    await engin.stop()
+
+    assert received == "prefix_foo", f"invocation should see modified value, got {received}"


### PR DESCRIPTION
## Summary

- **Block-scoped modifiers**: `Modify` declared inside a `Block` now only affects resolutions within that block's scope, matching fx/dig's scoped decorator behavior. Modifiers in BlockA don't leak to BlockB or top-level invocations.
- **Modifier composition**: Block modifiers compose with global modifiers — a block modifier receives the globally-modified value as input (e.g., global prefix + block uppercase = `"GLOBAL_FOO"`).
- **Bug fix**: `_bind_arguments` (used by `assemble()`) now applies modifiers. Previously, invocations assembled via `assemble()` received raw provider values, bypassing all modifiers.

### Implementation details

- `_ScopeNode` extended with `modifiers` dict and `find_modifier()` chain walk (mirrors dig's `storesToRoot()`)
- Global modifiers moved from `Assembler._modifiers` onto `root_node.modifiers`
- Block scope nodes are persistent `_ScopeNode` instances parented to root, created during `Block.apply()`
- `Engin.run()` sets `_scope_var` to the block's node when assembling/invoking block invocations
- Instance-level on-stack tracking (`set[int]` of modifier IDs) replaces type-level tracking to allow modifier composition across scope levels
- Modified values cached on the modifier's source node (not always root) to prevent cross-scope leaking
- `find_modified()` stops at nodes owning a modifier for the type, preventing inheritance of parent's cached modified value

## Test plan

- [x] Block modifier only affects block's own invocations
- [x] Block modifier does not affect other blocks
- [x] Block + global modifier composition (block receives globally-modified value)
- [x] Global modifier works through Engin invocation path (not just `Assembler.build`)
- [x] All 143 existing + new tests pass
- [x] `poe check` passes (ruff format, ruff lint, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)