### PR TITLE
Bugfix: Assembler no longer modifies multiprovider supplied list

### DIFF
--- a/src/engin/_assembler.py
+++ b/src/engin/_assembler.py
@@ -424,10 +424,9 @@ class Assembler:
                 ) from err
 
             if provider.is_multiprovider:
-                if type_id in self._root_node.cache:
-                    self._root_node.cache[type_id].extend(value)
-                else:
-                    self._root_node.cache[type_id] = value
+                if type_id not in self._root_node.cache:
+                    self._root_node.cache[type_id] = []
+                self._root_node.cache[type_id].extend(value)
             elif provider.scope:
                 scope.cache[type_id] = value
             else:

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import pytest
 
-from engin import Assembler, Entrypoint, Invoke, Provide
+from engin import Assembler, Entrypoint, Invoke, Provide, Supply
 from engin.exceptions import NotInScopeError, ProviderError, TypeNotProvidedError
 from tests.deps import int_provider, make_many_int, make_many_int_alt, make_str
 
@@ -133,6 +133,22 @@ async def test_assembler_has_multi():
     assert assembler.has(list[str])
     assert not assembler.has(int)
     assert not assembler.has(str)
+
+
+async def test_assembler_does_not_modify_multiprovider_values():
+    def multidependency_user(values: list[int]) -> int:
+        return 42
+
+    provider = Provide(multidependency_user)
+    providers = [Supply([1]), Supply([2]), provider]
+
+    assembler1 = Assembler(providers)
+    assembler2 = Assembler(providers)
+    await assembler1.assemble(providers[2])
+    await assembler2.assemble(providers[2])
+
+    assert providers[0]._value == [1]
+    assert providers[1]._value == [2]
 
 
 async def test_assembler_add():


### PR DESCRIPTION
A unit test I added describes the problem.

Assembler used to extend the list (value) from the Multi-dependency Provider with the rest of Multi-dependencies of the same type.
This was an issue with `Supply([value])` as it led to Supply value being modified after repeated `assemble()` invocations, resulting in duplicated Multi-dependency values.